### PR TITLE
Added support to multiple pages on bing news

### DIFF
--- a/search_engines/ask_search.py
+++ b/search_engines/ask_search.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//li[@class="PartialWebPagination-condensed PartialWebPagination-pgsel PartialWebPagination-button"]/text()'))

--- a/search_engines/bing_news.py
+++ b/search_engines/bing_news.py
@@ -1,13 +1,16 @@
-from search_engines.utils import extract_first, join_all, publish_time
+from search_engines.utils import extract_first, publish_time
 from lxml.html import fromstring
 from typing import Dict, List, Tuple
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit, parse_qs
 import re
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     results = []
+    params = dict(parse_qs(urlsplit(page_url).query))
+    current_page = str(int(((int(params["first"][0]) - 1) / 10) + 1))
+
     for result in root.xpath('//div[@class="news-card newsitem cardcommon b_cards2"]'):
         pub_time = extract_first(
             result.xpath('.//div[@class="source"]//span/@aria-label'))
@@ -18,16 +21,13 @@ def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
             'preview_text': extract_first(result.xpath('.//div[@class="snippet"]/@title')),
             'publisher': extract_first(result.xpath('.//div[@class="source"]//a[@aria-label]/text()')),
             'publish_date': publish_date.group() if publish_date else publish_time(pub_time),
-            'page_number': "1",
+            'page_number': current_page,
         })
-    """
-    next_page_url = extract_first(root.xpath("//a[@title='Next page']/@href"))
-    if next_page_url:
-        next_page_url = 'https://www.bing.com' + next_page_url
-    """
-    # now a single page. need to scroll to load all content.
-    return results, None
+
+    next_page_url = f'https://www.bing.com/news/infinitescrollajax?q={quote(params["q"][0])}&InfiniteScroll=1&first=' + str(int(params["first"][0]) + 10)
+
+    return results, next_page_url
 
 
 def get_search_url(query: str):
-    return f'https://www.bing.com/news/search?q={quote(query)}'
+    return f'https://www.bing.com/news/infinitescrollajax?q={quote(query)}&InfiniteScroll=1&first=1'

--- a/search_engines/bing_search.py
+++ b/search_engines/bing_search.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(
         root.xpath('//a[@class="sb_pagS sb_pagS_bp b_widePag sb_bp"]/text()'))

--- a/search_engines/dogpile_news.py
+++ b/search_engines/dogpile_news.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//span[@class="pagination__num pagination__num--active"]/text()'))

--- a/search_engines/dogpile_search.py
+++ b/search_engines/dogpile_search.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//span[@class="pagination__num pagination__num--active"]/text()'))

--- a/search_engines/google_news.py
+++ b/search_engines/google_news.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//*[@role="navigation"]//tr/td[@class="YyVfkd"]/text()'))

--- a/search_engines/google_search.py
+++ b/search_engines/google_search.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//*[@role="navigation"]//tr/td[@class="YyVfkd"]/text()'))

--- a/search_engines/search_engines.py
+++ b/search_engines/search_engines.py
@@ -92,7 +92,7 @@ async def _scrape_page(task_data: Dict[str, Any], task_queue: TaskQueue, loader:
     module = _get_engine_module(task_data['engine'])
     # load page.
     await loader.fetch(task_data['url'])
-    results, next_page_url = module.extract_search_results(loader.html)
+    results, next_page_url = module.extract_search_results(loader.html, task_data['url'])
     # results is a list of Dict[str,str]
     # add results to this tasks result list.
     await task_queue.redis.lpush(_search_results_key(task_data['task_id']), pickle.dumps(results))

--- a/search_engines/yahoo_news.py
+++ b/search_engines/yahoo_news.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(
         root.xpath('//div[@class="compPagination"]//strong/text()'))

--- a/search_engines/yahoo_search.py
+++ b/search_engines/yahoo_search.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import quote
 
 
-def extract_search_results(html: str) -> Tuple[List[Dict[str, str]], str]:
+def extract_search_results(html: str, page_url: str) -> Tuple[List[Dict[str, str]], str]:
     root = fromstring(html)
     page_number = extract_first(root.xpath(
         '//div[@class="compPagination"]//strong/text()'))


### PR DESCRIPTION
Hello, 

I added support for searching multiple pages in the bing news, not it is searching directly from the api.

I also found a problem when using Yahoo News, because I am using it from other country and the Yahoo URL is https://au.news.search.yahoo.com/search?p, it would be possible to put the country option in the initial settings or would you have another idea to fix it?